### PR TITLE
Add Test::META to test-depends

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -10,6 +10,9 @@
         "provides" : {
             "Text::Names": "lib/Text/Names.pm6"
         },
+        "depends" : [ ],
+        "build-depends" : [ ],
+        "test-depends" : [ "Test::META" ],
         "tags": [
           "NPL", "Natural Language", "Names", "Dummy Data"
         ],


### PR DESCRIPTION
Otherwise tests may fail if the dependency is not installed.